### PR TITLE
Modify stepik-courses.sh to show course titles without quotes

### DIFF
--- a/stepik-courses.sh
+++ b/stepik-courses.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq '."course-lists"[].title'
+curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq -r '."course-lists"[].title'


### PR DESCRIPTION
The -r command was added to show the course titles without double quotes