### PR TITLE
Remove quotes from course names

### DIFF
--- a/stepik-courses.sh
+++ b/stepik-courses.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq '."course-lists"[].title'
+curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq | tr -d '"'


### PR DESCRIPTION
add curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq | tr -d '"'