### PR TITLE
Remove quotes from course names stepik-courses.sh

### DIFF
--- a/stepik-courses.sh
+++ b/stepik-courses.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq '."course-lists"[].title'
+curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq | tr -d '"'itle'


### PR DESCRIPTION
add curl -s [https://stepik.org:443/api/course-lists\?page\=1](https://stepik.org/api/course-lists%5C?page%5C=1) | jq | tr -d '"'
Now it will be Course list without quotes